### PR TITLE
feat: Bump action to node20

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -27,7 +27,7 @@ outputs:
   comment-created:
     description: 'Whether or not the comment was created on the pull request.'
 runs:
-  using: 'node16'
+  using: 'node20'
   main: 'dist/index.js'
 branding:
   icon: 'moon'

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@moonrepo/run-report-action",
-  "version": "1.5.1",
+  "version": "1.5.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@moonrepo/run-report-action",
-      "version": "1.5.1",
+      "version": "1.5.2",
       "license": "MIT",
       "dependencies": {
         "@actions/core": "^1.10.1",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,7 +2,7 @@
   "extends": "tsconfig-moon/tsconfig.json",
   "compilerOptions": {
     "allowJs": true,
-    "module": "Node16",
+    "module": "NodeNext",
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "verbatimModuleSyntax": false


### PR DESCRIPTION
<img width="1446" alt="Screenshot 2024-02-02 at 12 19 09 am" src="https://github.com/moonrepo/run-report-action/assets/683160/9f2a27ce-62db-478e-9c3b-8ad48acbd1b3">

Kept receiving the following warning while running my ci jobs and trying to keep noise to a minimum, so thought I would bump to node20. Also noticed that the package lock must not have been run the last time the version was updated. 