### PR TITLE
Set report output & skip comment

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -26,6 +26,8 @@ inputs:
 outputs:
   comment-created:
     description: 'Whether or not the comment was created on the pull request.'
+  report:
+    description: 'The generated report.'
 runs:
   using: 'node20'
   main: 'dist/index.js'

--- a/action.yml
+++ b/action.yml
@@ -11,6 +11,9 @@ inputs:
   matrix:
     description: 'Metadata about the current job matrix in JSON.'
     default: ''
+  skip-comment:
+    description: 'Skip creating a comment. Useful alongside `report` output.'
+    default: false
   slow-threshold:
     description: 'Number of seconds before an action is to be considered slow.'
     default: 120

--- a/action.yml
+++ b/action.yml
@@ -13,7 +13,7 @@ inputs:
     default: ''
   skip-comment:
     description: 'Skip creating a comment. Useful alongside `report` output.'
-    default: false
+    default: 'false'
   slow-threshold:
     description: 'Number of seconds before an action is to be considered slow.'
     default: 120

--- a/index.ts
+++ b/index.ts
@@ -118,6 +118,7 @@ async function run() {
 
 		// Format the report into markdown
 		const markdown = formatReportToMarkdown(report, { limit, slowThreshold, workspaceRoot });
+		core.setOutput('report', markdown);
 
 		// Create the comment (does not work in forks)
 		try {

--- a/index.ts
+++ b/index.ts
@@ -89,6 +89,7 @@ async function run() {
 	try {
 		const accessToken = core.getInput('access-token');
 		const limit = Number(core.getInput('limit'));
+		const skipComment = core.getInput('skip-comment') === 'true';
 		const slowThreshold = Number(core.getInput('slow-threshold'));
 		const workspaceRoot =
 			core.getInput('workspace-root') || process.env.GITHUB_WORKSPACE || process.cwd();
@@ -119,6 +120,12 @@ async function run() {
 		// Format the report into markdown
 		const markdown = formatReportToMarkdown(report, { limit, slowThreshold, workspaceRoot });
 		core.setOutput('report', markdown);
+
+		if (skipComment) {
+			core.debug('Skipping comment creation');
+			core.setOutput('comment-created', 'false');
+			return;
+		}
 
 		// Create the comment (does not work in forks)
 		try {

--- a/index.ts
+++ b/index.ts
@@ -89,7 +89,7 @@ async function run() {
 	try {
 		const accessToken = core.getInput('access-token');
 		const limit = Number(core.getInput('limit'));
-		const skipComment = core.getInput('skip-comment') === 'true';
+		const skipComment = core.getBooleanInput('skip-comment');
 		const slowThreshold = Number(core.getInput('slow-threshold'));
 		const workspaceRoot =
 			core.getInput('workspace-root') || process.env.GITHUB_WORKSPACE || process.cwd();
@@ -123,23 +123,21 @@ async function run() {
 
 		if (skipComment) {
 			core.debug('Skipping comment creation');
-			core.setOutput('comment-created', 'false');
-			return;
-		}
-
-		// Create the comment (does not work in forks)
-		try {
-			await saveComment(accessToken, markdown);
-		} catch (error: unknown) {
-			core.warning(String(error));
-			core.notice('\nFailed to create comment on pull request. Perhaps this is ran in a fork?\n');
-			core.info(markdown);
+		} else {
+			// Create the comment (does not work in forks)
+			try {
+				await saveComment(accessToken, markdown);
+			} catch (error: unknown) {
+				core.warning(String(error));
+				core.notice('\nFailed to create comment on pull request. Perhaps this is ran in a fork?\n');
+				core.info(markdown);
+			}
 		}
 
 		// Create an action summary (does work in forks)
 		await saveSummary(markdown);
 
-		core.setOutput('comment-created', 'true');
+		core.setOutput('comment-created', skipComment ? 'false' : 'true');
 	} catch (error: unknown) {
 		core.setOutput('comment-created', 'false');
 		core.setFailed((error as Error).message);


### PR DESCRIPTION
Allow the report to be generated & accessed, but no PR comment raised; this allows more complex workflows to use this action for rendering only.